### PR TITLE
fix: phantom test failures

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -3,7 +3,7 @@ src = "src"
 out = "out"
 libs = ["lib"]
 solc = "0.8.24"
-optimizer_runs = 100000
+optimizer_runs = 100_000
 remappings = [
     "forge-std/=lib/forge-std/src/",
     "openzeppelin-contracts/=lib/openzeppelin-contracts/contracts",
@@ -12,7 +12,7 @@ remappings = [
 
 [profile.default.fuzz]
 max_test_rejects = 1_000_000
-runs = 1000
+runs = 1_000
 seed = "0xee1d0f7d9556539a9c0e26aed5e63556"
 
 [profile.default.fmt]

--- a/test/unit/View.t.sol
+++ b/test/unit/View.t.sol
@@ -7,6 +7,7 @@ import "evc/EthereumVaultConnector.sol";
 import "../harness/BaseRewardStreamsHarness.sol";
 import {MockERC20} from "../utils/MockERC20.sol";
 import {MockController} from "../utils/MockController.sol";
+import {boundAddr} from "../utils/TestUtils.sol";
 
 contract ViewTest is Test {
     EthereumVaultConnector internal evc;
@@ -18,6 +19,8 @@ contract ViewTest is Test {
     }
 
     function test_EnabledRewards(address account, address rewarded, uint8 n, bytes memory seed) external {
+        account = boundAddr(account);
+        rewarded = boundAddr(rewarded);
         n = uint8(bound(n, 1, 5));
 
         vm.startPrank(account);

--- a/test/utils/TestUtils.sol
+++ b/test/utils/TestUtils.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity ^0.8.24;
+
+address constant VM_ADDRESS = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
+address constant CONSOLE = 0x000000000000000000636F6e736F6c652e6c6f67;
+address constant CREATE2_FACTORY = 0x4e59b44847b379578588920cA78FbF26c0B4956C;
+address constant DEFAULT_TEST_CONTRACT = 0x5615dEB798BB3E4dFa0139dFa1b3D433Cc23b72f;
+address constant MULTICALL3_ADDRESS = 0xcA11bde05977b3631167028862bE2a173976CA11;
+address constant FIRST_DEPLOYED_CONTRACT = 0x2e234DAe75C793f67A35089C9d99245E1C58470b;
+
+/// @dev Exclude Foundry precompiles and predeploys.
+/// These addresses can make certain test cases that call/mockCall to them fail.
+/// List of Foundry precompiles: https://book.getfoundry.sh/misc/precompile-registry
+function boundAddr(address addr) pure returns (address) {
+    if (
+        uint160(addr) < 10 || addr == VM_ADDRESS || addr == CONSOLE || addr == CREATE2_FACTORY
+            || addr == DEFAULT_TEST_CONTRACT || addr == MULTICALL3_ADDRESS || addr == FIRST_DEPLOYED_CONTRACT
+    ) {
+        return address(uint160(addr) + 10);
+    }
+
+    return addr;
+}


### PR DESCRIPTION
These phantom test failures that we're observing are due to address collisions when fuzzing. When we see one pop up for a test case we should call `boundAddr` to squash it.